### PR TITLE
fix: improve release workflow version generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,23 +44,20 @@ jobs:
           # Generate date-based version with build number
           DATE=$(date -u +%Y.%-m.%-d)
           
-          # Get build number for today (count of commits today + 1)
-          BUILD_NUM=$(git log --since="00:00:00" --format=oneline | wc -l | xargs)
-          BUILD_NUM=$((BUILD_NUM + 1))
+          # Find the highest build number for today
+          BUILD_NUM=1
+          for tag in $(git tag -l "v${DATE}.*" | sort -V); do
+            current_num=$(echo "$tag" | sed "s/v${DATE}\.//" | grep -E '^[0-9]+$' || echo "0")
+            if [ "$current_num" -ge "$BUILD_NUM" ]; then
+              BUILD_NUM=$((current_num + 1))
+            fi
+          done
           
           # Create version string
           VERSION="v${DATE}.${BUILD_NUM}"
           
           echo "Generated version: $VERSION"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      
-      - name: Check if tag exists
-        id: tag_check
-        run: |
-          if git rev-parse "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "Tag already exists, incrementing build number..."
-            exit 1
-          fi
       
       - name: Create tag
         run: |


### PR DESCRIPTION
## Summary
Fixed the release workflow to properly handle incrementing build numbers when tags already exist for the current date.

## Problem
The release workflow was failing with the error:
```
Tag already exists, incrementing build number...
Process completed with exit code 1.
```

When trying to create release `v2025.9.9.3`, the workflow detected the tag already existed but failed instead of properly incrementing to the next available version.

## Solution
Improved the version generation logic to:
- Find all existing tags for today's date using `git tag -l "v${DATE}.*"`
- Extract and compare build numbers from existing tags
- Automatically increment to the next available build number
- Remove the unnecessary "Check if tag exists" step that was causing failures

This ensures releases can be created multiple times per day without manual intervention.

## Test plan
- [x] Workflow generates `v2025.9.9.4` when `v2025.9.9.3` already exists
- [ ] Multiple releases can be triggered on the same day
- [ ] Tags are created with correct incremental build numbers

🤖 Generated with [Claude Code](https://claude.ai/code)