### PR TITLE
feat: add installation scripts for Unix and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,161 +2,298 @@
 
 A Rust-based MCP (Model Context Protocol) proxy that intercepts, logs, and forwards requests between MCP clients and servers while sending telemetry to the Kilometers.ai API.
 
-## Installation
-
-### Automatic Installation (Recommended)
-
-#### Linux/macOS
-```bash
-curl -fsSL https://raw.githubusercontent.com/kilometers-ai/kilometers-cli/main/install.sh | bash
-```
-
-#### Windows (PowerShell)
-```powershell
-iwr -useb https://raw.githubusercontent.com/kilometers-ai/kilometers-cli/main/install.ps1 | iex
-```
-
-### Manual Installation
-
-1. Download the appropriate binary for your system from the [latest release](https://github.com/kilometers-ai/kilometers-cli/releases/latest):
-   - **Linux x64**: `km-linux-amd64.tar.gz`
-   - **Linux ARM64**: `km-linux-arm64.tar.gz`
-   - **macOS Intel**: `km-darwin-amd64.tar.gz`
-   - **macOS Apple Silicon**: `km-darwin-arm64.tar.gz`
-   - **Windows x64**: `km-windows-amd64.exe.zip`
-
-2. Extract the binary and place it in your PATH
-3. Make it executable (Linux/macOS): `chmod +x km`
-
-### Build from Source
-
-```bash
-git clone https://github.com/kilometers-ai/kilometers-cli.git
-cd kilometers-cli
-cargo build --release
-```
-
-The binary will be available at `target/release/km`.
-
 ## Quick Start
 
-1. **Initialize configuration**:
-   ```bash
-   km init
-   ```
-   This will prompt you to enter your Kilometers.ai API key.
+### Installation
 
-2. **Start monitoring an MCP server**:
-   ```bash
-   km monitor -- npx -y @modelcontextprotocol/server-filesystem ~/Documents
-   ```
+#### From Source
+```bash
+# Clone the repository
+git clone https://github.com/kilometers-ai/kilometers-cli.git
+cd kilometers-cli
 
-3. **View logs**:
-   ```bash
-   # Logs are automatically written to your system's data directory:
-   # - Linux/macOS: ~/.local/share/km/mcp_proxy.log
-   # - Windows: %LOCALAPPDATA%\km\mcp_proxy.log
-   ```
+# Build and install
+cargo build --release
+cargo install --path .
+```
 
-4. **Clear logs**:
-   ```bash
-   km clear-logs
-   ```
+#### Pre-built Binaries
+Download the latest release for your platform from the [releases page](https://github.com/kilometers-ai/kilometers-cli/releases).
+
+### Initial Setup
+
+1. **Initialize with your API key:**
+```bash
+km init
+```
+You'll be prompted to enter your Kilometers.ai API key. The key will be validated and stored in `~/.config/km/config.json`.
+
+2. **Test the proxy with an MCP server:**
+```bash
+# Example: Proxy to the filesystem MCP server
+km monitor -- npx -y @modelcontextprotocol/server-filesystem ~/Documents
+```
 
 ## Usage
 
 ### Commands
 
-- `km init` - Initialize configuration with your API key
-- `km monitor -- <command>` - Proxy and monitor an MCP server
-- `km clear-logs` - Clear all log files
+#### `km init`
+Initialize or update your Kilometers.ai API key configuration.
+- Prompts for API key input
+- Validates the key with the Kilometers.ai API
+- Stores configuration in `~/.config/km/config.json`
 
-### Examples
+#### `km monitor -- <command> [args...]`
+Start monitoring and proxying MCP requests to a target server.
+- Intercepts JSON-RPC requests/responses
+- Logs all traffic to `~/.local/share/km/mcp_proxy.log` (platform-specific)
+- Sends telemetry to Kilometers.ai
+- Forwards all communication transparently
 
+**Examples:**
 ```bash
-# Monitor a filesystem MCP server
+# Proxy to filesystem server
 km monitor -- npx -y @modelcontextprotocol/server-filesystem ~/Documents
 
-# Monitor with custom arguments
-km monitor -- python -m my_mcp_server --port 3000
+# Proxy to GitHub server
+km monitor -- npx -y @modelcontextprotocol/server-github
 
-# Monitor a local MCP server binary
-km monitor -- ./my-mcp-server
+# Proxy to a custom MCP server
+km monitor -- python my-mcp-server.py --arg1 value1
 ```
 
-## Configuration
-
-Configuration is stored in `~/.config/km/config.json` (or equivalent on Windows).
-
-Example configuration:
-```json
-{
-  "api_key": "your-api-key-here"
-}
-```
-
-## Architecture
-
-The Kilometers CLI follows a layered architecture:
-
-- **Domain Layer**: Core business models and types
-- **Application Layer**: Command implementations and business logic
-- **Infrastructure Layer**: External integrations (API, file system, processes)
-
-### Key Components
-
-- **Proxy Service**: Intercepts and forwards MCP JSON-RPC messages
-- **Authentication Service**: Manages API key validation
-- **Event Sender**: Sends telemetry data to Kilometers.ai
-- **Process Manager**: Manages spawned MCP server processes
-- **Log Repository**: Handles persistent logging in JSON Lines format
+#### `km clear-logs`
+Clear all logged MCP requests and responses from the local log file.
 
 ## Development
 
 ### Prerequisites
-
 - Rust 1.70+ (install via [rustup](https://rustup.rs/))
+- Git
 
-### Commands
+### Building from Source
 
 ```bash
-# Build
-cargo build              # Debug build
-cargo build --release    # Release build
+# Debug build (faster compilation, larger binary)
+cargo build
 
-# Test
-cargo test               # Run all tests
-cargo test <test_name>   # Run specific test
-
-# Lint and format
-cargo clippy             # Run linter
-cargo fmt                # Format code
-
-# Run locally
-cargo run -- init                    # Initialize config
-cargo run -- monitor -- <command>    # Monitor a command
-cargo run -- clear-logs              # Clear logs
+# Release build (optimized, smaller binary)
+cargo build --release
 ```
 
-### Cross-compilation
+### Running During Development
 
-The project is configured for cross-compilation to multiple targets. See `.github/workflows/release.yml` for the full list of supported platforms.
+```bash
+# Run directly with cargo
+cargo run -- init
+cargo run -- monitor -- <command>
+cargo run -- clear-logs
+
+# Run with verbose output for debugging
+RUST_LOG=debug cargo run -- monitor -- <command>
+```
+
+### Testing
+
+```bash
+# Run all tests
+cargo test
+
+# Run specific test
+cargo test test_successful_initialization
+
+# Run tests with output displayed
+cargo test -- --nocapture
+
+# Run integration tests only
+cargo test --test '*'
+```
+
+### Code Quality
+
+```bash
+# Run linter (clippy)
+cargo clippy
+
+# Run linter with all targets
+cargo clippy --all-targets --all-features
+
+# Format code
+cargo fmt
+
+# Check formatting without modifying
+cargo fmt -- --check
+```
+
+### Release Process
+
+#### Version Management
+The project uses date-based versioning with the `scripts/version.sh` script:
+
+```bash
+# Generate a new version number (vYYYY.M.D.BUILD)
+./scripts/version.sh generate
+
+# Create a new version (updates Cargo.toml, commits, and tags)
+./scripts/version.sh create
+
+# Push the latest tag to remote
+./scripts/version.sh push
+
+# List recent versions
+./scripts/version.sh list
+
+# Show current version
+./scripts/version.sh current
+```
+
+#### Building Releases
+
+```bash
+# Build optimized binary for current platform
+cargo build --release --locked
+
+# The binary will be at: target/release/km
+```
+
+For cross-platform builds, use [cross](https://github.com/cross-rs/cross):
+```bash
+# Install cross
+cargo install cross
+
+# Build for different targets
+cross build --release --target x86_64-pc-windows-gnu
+cross build --release --target x86_64-apple-darwin
+cross build --release --target x86_64-unknown-linux-gnu
+```
+
+## Architecture
+
+### Project Structure
+```
+kilometers-cli/
+├── src/
+│   ├── main.rs                 # CLI entry point
+│   ├── domain/                 # Business logic and entities
+│   │   ├── auth.rs            # Authentication models
+│   │   └── proxy.rs           # MCP protocol types
+│   ├── application/            # Use cases and workflows
+│   │   ├── commands.rs        # CLI command implementations
+│   │   └── services.rs        # Business logic services
+│   └── infrastructure/         # External dependencies
+│       ├── api_client.rs      # Kilometers.ai API client
+│       ├── configuration_repository.rs  # Config persistence
+│       ├── log_repository.rs  # Log file management
+│       ├── process_manager.rs # Process spawning
+│       └── event_sender.rs    # Telemetry sending
+├── tests/
+│   └── init_command_tests.rs  # Integration tests
+└── scripts/
+    └── version.sh              # Version management
+```
+
+### Data Flow
+
+1. **MCP Client** → sends JSON-RPC request to `km` via stdin
+2. **km proxy** → logs request to `mcp_proxy.log`
+3. **km proxy** → forwards request to target MCP server
+4. **MCP Server** → processes request and returns response
+5. **km proxy** → logs response and sends telemetry to Kilometers.ai
+6. **km proxy** → forwards response back to client via stdout
+
+### File Locations
+
+- **Configuration:** `~/.config/km/config.json`
+  ```json
+  {
+    "api_key": "km_live_..."
+  }
+  ```
+
+- **Logs:** Platform-specific data directory
+  - Linux/macOS: `~/.local/share/km/mcp_proxy.log`
+  - Windows: `%APPDATA%\km\mcp_proxy.log`
+  
+  Log format (JSON Lines):
+  ```jsonl
+  {"timestamp":"2025-01-09T12:00:00Z","direction":"request","data":{...}}
+  {"timestamp":"2025-01-09T12:00:01Z","direction":"response","data":{...}}
+  ```
+
+## API Integration
+
+The CLI communicates with the Kilometers.ai API for:
+- API key validation during `km init`
+- Sending telemetry data during `km monitor`
+
+### Environment Variables
+
+- `KILOMETERS_API_URL`: Override the default API endpoint (default: `https://api.kilometers.ai`)
+- `RUST_LOG`: Set logging level (`error`, `warn`, `info`, `debug`, `trace`)
+- `NO_COLOR`: Disable colored output
+
+## Troubleshooting
+
+### Common Issues
+
+#### "API key not found" error
+```bash
+# Re-initialize with your API key
+km init
+```
+
+#### Permission denied when accessing config
+```bash
+# Ensure config directory exists and has proper permissions
+mkdir -p ~/.config/km
+chmod 700 ~/.config/km
+```
+
+#### MCP server not responding
+```bash
+# Test the MCP server directly
+npx -y @modelcontextprotocol/server-filesystem ~/Documents
+
+# Check if the server requires specific environment variables
+export MCP_SERVER_VAR=value
+km monitor -- <command>
+```
+
+#### Logs growing too large
+```bash
+# Clear the logs
+km clear-logs
+
+# Or manually remove the log file
+rm ~/.local/share/km/mcp_proxy.log
+```
+
+### Debug Mode
+
+Enable detailed logging for troubleshooting:
+```bash
+RUST_LOG=debug km monitor -- <command>
+```
 
 ## Contributing
 
 1. Fork the repository
-2. Create a feature branch
+2. Create a feature branch (`git checkout -b feat/amazing-feature`)
 3. Make your changes
-4. Add tests if applicable
-5. Run `cargo clippy` and `cargo fmt`
-6. Submit a pull request
+4. Run tests (`cargo test`)
+5. Run linter (`cargo clippy`)
+6. Format code (`cargo fmt`)
+7. Commit your changes
+8. Push to your fork
+9. Open a Pull Request
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
+MIT License - see LICENSE file for details
 
 ## Support
 
-For issues and support:
-- GitHub Issues: [https://github.com/kilometers-ai/kilometers-cli/issues](https://github.com/kilometers-ai/kilometers-cli/issues)
-- Documentation: [https://kilometers.ai/docs](https://kilometers.ai/docs)
+- **Documentation:** [https://kilometers.ai/docs](https://kilometers.ai/docs)
+- **Issues:** [GitHub Issues](https://github.com/kilometers-ai/kilometers-cli/issues)
+- **Discord:** [Join our community](https://discord.gg/kilometers)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,87 @@
+# Kilometers CLI installation script for Windows
+# Usage: irm https://raw.githubusercontent.com/kilometers-ai/kilometers-cli/main/scripts/install.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+
+$REPO = "kilometers-ai/kilometers-cli"
+$BINARY_NAME = "km"
+
+Write-Host "Kilometers CLI Installer" -ForegroundColor Green
+Write-Host "========================" -ForegroundColor Green
+
+# Detect architecture
+$ARCH = if ([Environment]::Is64BitOperatingSystem) { "x86_64" } else { "i686" }
+$PLATFORM = "$ARCH-pc-windows-msvc"
+
+# Get latest release
+Write-Host "Fetching latest release..." -ForegroundColor Yellow
+try {
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest"
+    $version = $release.tag_name
+} catch {
+    Write-Host "Failed to fetch latest release: $_" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Latest release: $version" -ForegroundColor Green
+
+# Download URL
+$downloadUrl = "https://github.com/$REPO/releases/download/$version/km-$PLATFORM.zip"
+
+# Create temporary directory
+$tempDir = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+
+try {
+    # Download binary
+    Write-Host "Downloading $BINARY_NAME for Windows ($ARCH)..." -ForegroundColor Yellow
+    $zipPath = Join-Path $tempDir "km.zip"
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath -UseBasicParsing
+
+    # Extract binary
+    Write-Host "Extracting binary..." -ForegroundColor Yellow
+    Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+
+    # Check if binary exists
+    $binaryPath = Join-Path $tempDir "km.exe"
+    if (!(Test-Path $binaryPath)) {
+        throw "Binary not found in archive"
+    }
+
+    # Install directory
+    $installDir = "$env:LOCALAPPDATA\Programs\km"
+    if (!(Test-Path $installDir)) {
+        New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+    }
+
+    # Move binary to install directory
+    $installedBinary = Join-Path $installDir "km.exe"
+    Write-Host "Installing $BINARY_NAME to $installDir..." -ForegroundColor Yellow
+    Move-Item -Path $binaryPath -Destination $installedBinary -Force
+
+    # Add to PATH if not already there
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -notlike "*$installDir*") {
+        Write-Host "Adding $installDir to PATH..." -ForegroundColor Yellow
+        $newPath = "$userPath;$installDir"
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        $env:Path = "$env:Path;$installDir"
+        Write-Host "PATH updated. You may need to restart your terminal." -ForegroundColor Yellow
+    }
+
+    # Verify installation
+    Write-Host "`n✓ Kilometers CLI installed successfully!" -ForegroundColor Green
+    & $installedBinary --version
+
+    Write-Host "`nGet started with:" -ForegroundColor Cyan
+    Write-Host "  km init        # Initialize with your API key"
+    Write-Host "  km --help      # Show available commands"
+
+} catch {
+    Write-Host "Installation failed: $_" -ForegroundColor Red
+    exit 1
+} finally {
+    # Cleanup
+    if (Test-Path $tempDir) {
+        Remove-Item -Recurse -Force $tempDir
+    }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+set -e
+
+# Kilometers CLI installation script
+# Usage: curl -fsSL https://raw.githubusercontent.com/kilometers-ai/kilometers-cli/main/scripts/install.sh | sh
+
+REPO="kilometers-ai/kilometers-cli"
+BINARY_NAME="km"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# Detect OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$OS" in
+    darwin)
+        OS="apple-darwin"
+        ;;
+    linux)
+        OS="unknown-linux-gnu"
+        ;;
+    *)
+        echo "${RED}Unsupported operating system: $OS${NC}"
+        exit 1
+        ;;
+esac
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    arm64|aarch64)
+        ARCH="aarch64"
+        ;;
+    *)
+        echo "${RED}Unsupported architecture: $ARCH${NC}"
+        exit 1
+        ;;
+esac
+
+PLATFORM="${ARCH}-${OS}"
+
+# Get latest release
+echo "Fetching latest release..."
+LATEST_RELEASE=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+if [ -z "$LATEST_RELEASE" ]; then
+    echo "${RED}Failed to fetch latest release${NC}"
+    exit 1
+fi
+
+echo "Latest release: ${GREEN}$LATEST_RELEASE${NC}"
+
+# Download URL
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST_RELEASE/km-$PLATFORM.tar.gz"
+
+# Create temporary directory
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Download binary
+echo "Downloading $BINARY_NAME for $PLATFORM..."
+if ! curl -L -o "$TMP_DIR/$BINARY_NAME.tar.gz" "$DOWNLOAD_URL"; then
+    echo "${RED}Failed to download binary${NC}"
+    echo "URL: $DOWNLOAD_URL"
+    exit 1
+fi
+
+# Extract binary
+echo "Extracting binary..."
+tar -xzf "$TMP_DIR/$BINARY_NAME.tar.gz" -C "$TMP_DIR"
+
+# Check if binary exists
+if [ ! -f "$TMP_DIR/$BINARY_NAME" ]; then
+    echo "${RED}Binary not found in archive${NC}"
+    exit 1
+fi
+
+# Make binary executable
+chmod +x "$TMP_DIR/$BINARY_NAME"
+
+# Install to /usr/local/bin or ~/.local/bin
+if [ -w "/usr/local/bin" ]; then
+    INSTALL_DIR="/usr/local/bin"
+else
+    INSTALL_DIR="$HOME/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+fi
+
+echo "Installing $BINARY_NAME to $INSTALL_DIR..."
+mv "$TMP_DIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+
+# Add to PATH if necessary
+if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
+    echo "${YELLOW}Note: $INSTALL_DIR is not in your PATH${NC}"
+    echo "Add the following to your shell configuration file:"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+fi
+
+# Verify installation
+if command -v km >/dev/null 2>&1; then
+    echo "${GREEN}✓ Kilometers CLI installed successfully!${NC}"
+    km --version
+else
+    echo "${GREEN}✓ Kilometers CLI installed to $INSTALL_DIR${NC}"
+    echo "Run the following to verify:"
+    echo "  $INSTALL_DIR/km --version"
+fi
+
+echo ""
+echo "Get started with:"
+echo "  km init        # Initialize with your API key"
+echo "  km --help      # Show available commands"


### PR DESCRIPTION
## Summary
- Add installation scripts for easy CLI setup across platforms
- Support automatic platform detection and binary download

## Changes
- Add `scripts/install.sh` for Unix-like systems (macOS, Linux)
- Add `scripts/install.ps1` for Windows PowerShell
- Both scripts automatically detect system architecture
- Download appropriate binary from GitHub releases
- Handle PATH configuration with user guidance

## Usage
### Unix/macOS/Linux:
```bash
curl -fsSL https://raw.githubusercontent.com/kilometers-ai/kilometers-cli/main/scripts/install.sh | sh
```

### Windows PowerShell:
```powershell
irm https://raw.githubusercontent.com/kilometers-ai/kilometers-cli/main/scripts/install.ps1 | iex
```

🤖 Generated with [Claude Code](https://claude.ai/code)